### PR TITLE
Add support for blocking the Close function on the Waitgroup completing

### DIFF
--- a/contrib/waitgroup/runnable_test.go
+++ b/contrib/waitgroup/runnable_test.go
@@ -10,13 +10,30 @@ import (
 )
 
 func TestWaitAlive(t *testing.T) {
-	assert.True(t, New(&sync.WaitGroup{}).Alive())
+	testCases := []struct {
+		name         string
+		blockOnClose bool
+	}{
+		{
+			name:         "no block on close",
+			blockOnClose: false,
+		},
+		{
+			name:         "block on close",
+			blockOnClose: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.True(t, New(&sync.WaitGroup{}, tc.blockOnClose).Alive())
+		})
+	}
 }
 
-func TestWait(t *testing.T) {
+func TestWaitNoBlockOnClose(t *testing.T) {
 	wg := sync.WaitGroup{}
 	done := make(chan struct{})
-	runnable := New(&wg)
+	runnable := New(&wg, false)
 
 	go func() {
 		runnable.Run(context.Background())
@@ -32,4 +49,25 @@ func TestWait(t *testing.T) {
 	time.Sleep(50 * time.Millisecond) // Ensure goroutine has time to execute
 	runnable.Close(context.Background())
 	<-done
+}
+
+func TestWaitBlockOnClose(t *testing.T) {
+	var done bool
+	wg := sync.WaitGroup{}
+	runnable := New(&wg, true)
+
+	go func() {
+		runnable.Run(context.Background())
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(100 * time.Millisecond)
+		done = true
+	}()
+
+	time.Sleep(50 * time.Millisecond) // Ensure goroutine has time to execute
+	runnable.Close(context.Background())
+	assert.True(t, done)
 }


### PR DESCRIPTION
Update the `WaitGroup` runnable to add support for blocking the `Close` method on the `WaitGroup` completing.

This can be useful if using the runnable `Group` with `syncShutdown` set to `true`, and you want to ensure that the `WaitGroup` runnable is complete before signaling the next `Runnable` in the chain to complete/exit.